### PR TITLE
[1.x] Adds new Soapable Contract

### DIFF
--- a/src/Contracts/Soapable.php
+++ b/src/Contracts/Soapable.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace RicorocksDigitalAgency\Soap\Contracts;
+
+
+interface Soapable
+{
+    public function toSoap();
+}

--- a/src/Parameters/IntelligentBuilder.php
+++ b/src/Parameters/IntelligentBuilder.php
@@ -3,24 +3,19 @@
 namespace RicorocksDigitalAgency\Soap\Parameters;
 
 
+use RicorocksDigitalAgency\Soap\Contracts\Soapable;
+
 class IntelligentBuilder implements Builder
 {
     public function handle($parameters)
     {
-        return $this->walk($parameters);
-    }
-
-    protected function walk($parameters)
-    {
-        return collect($parameters)
-            ->map(fn($parameter) => $this->handleParameter($parameter))
-            ->toArray();
+        return $this->handleParameter($parameters);
     }
 
     protected function handleParameter($parameter)
     {
-        if ($parameter instanceof Node) {
-            $parameter = $parameter->toArray();
+        if ($parameter instanceof Soapable) {
+            $parameter = $parameter->toSoap();
         }
 
         if (is_array($parameter)) {
@@ -28,5 +23,12 @@ class IntelligentBuilder implements Builder
         }
 
         return $parameter;
+    }
+
+    protected function walk($parameters)
+    {
+        return collect($parameters)
+            ->map(fn($parameter) => $this->handleParameter($parameter))
+            ->toArray();
     }
 }

--- a/src/Parameters/Node.php
+++ b/src/Parameters/Node.php
@@ -3,8 +3,9 @@
 namespace RicorocksDigitalAgency\Soap\Parameters;
 
 use Illuminate\Contracts\Support\Arrayable;
+use RicorocksDigitalAgency\Soap\Contracts\Soapable;
 
-class Node implements Arrayable
+class Node implements Arrayable, Soapable
 {
     protected $name;
     protected $attributes = [];
@@ -26,5 +27,10 @@ class Node implements Arrayable
         return empty($this->body)
             ? array_merge(["_" => ""], $this->attributes)
             : array_merge($this->body, $this->attributes);
+    }
+
+    public function toSoap()
+    {
+        return $this->toArray();
     }
 }

--- a/tests/Building/IntelligentBuilderTest.php
+++ b/tests/Building/IntelligentBuilderTest.php
@@ -74,7 +74,8 @@ class IntelligentBuilderTest extends TestCase
 
         $this->assertEquals(
             [
-                'foo' => ['bar' => ['hello' => 'world'], 'email' => 'hi@me.com']
+                'foo' => ['bar' => ['hello' => 'world'], 'email' => 'hi@me.com'],
+                'bar' => ['baz', 'bang']
             ],
             $result
         );
@@ -94,7 +95,8 @@ class ExampleSoapable implements Soapable {
         return [
             'foo' => Soap
                 ::node(['email' => 'hi@me.com'])
-                ->body(['bar' => Soap::node()->body(['hello' => 'world'])])
+                ->body(['bar' => Soap::node()->body(['hello' => 'world'])]),
+            'bar' => ['baz', 'bang']
         ];
     }
 }

--- a/tests/Building/IntelligentBuilderTest.php
+++ b/tests/Building/IntelligentBuilderTest.php
@@ -2,6 +2,7 @@
 
 namespace RicorocksDigitalAgency\Soap\Tests\Building;
 
+use RicorocksDigitalAgency\Soap\Contracts\Soapable;
 use RicorocksDigitalAgency\Soap\Facades\Soap;
 use RicorocksDigitalAgency\Soap\Parameters\Builder;
 use RicorocksDigitalAgency\Soap\Parameters\IntelligentBuilder;
@@ -66,9 +67,34 @@ class IntelligentBuilderTest extends TestCase
         );
     }
 
+    /** @test */
+    public function it_can_handle_a_Soapable()
+    {
+        $result = $this->builder->handle(new ExampleSoapable);
+
+        $this->assertEquals(
+            [
+                'foo' => ['bar' => ['hello' => 'world'], 'email' => 'hi@me.com']
+            ],
+            $result
+        );
+    }
+
     protected function setUp(): void
     {
         parent::setUp();
         $this->builder = app(IntelligentBuilder::class);
+    }
+}
+
+class ExampleSoapable implements Soapable {
+
+    public function toSoap()
+    {
+        return [
+            'foo' => Soap
+                ::node(['email' => 'hi@me.com'])
+                ->body(['bar' => Soap::node()->body(['hello' => 'world'])])
+        ];
     }
 }

--- a/tests/SoapClassTest.php
+++ b/tests/SoapClassTest.php
@@ -4,14 +4,30 @@ namespace RicorocksDigitalAgency\Soap\Tests;
 
 use RicorocksDigitalAgency\Soap\Contracts\Soapable;
 use RicorocksDigitalAgency\Soap\Facades\Soap;
+use RicorocksDigitalAgency\Soap\Request\Request;
 use RicorocksDigitalAgency\Soap\Response\Response;
-use Spatie\Ray\Ray;
 
 class SoapClassTest extends TestCase
 {
     /** @test */
     public function it_can_obtain_a_wsdl()
     {
+        $this->mock(Request::class)
+            ->shouldReceive('beforeRequesting', 'afterRequesting', 'to')->andReturnSelf()
+            ->shouldReceive('functions')
+            ->andReturn(
+                [
+                    "AddResponse Add(Add \$parameters)",
+                    "SubtractResponse Subtract(Subtract \$parameters)",
+                    "MultiplyResponse Multiply(Multiply \$parameters)",
+                    "DivideResponse Divide(Divide \$parameters)",
+                    "AddResponse Add(Add \$parameters)",
+                    "SubtractResponse Subtract(Subtract \$parameters)",
+                    "MultiplyResponse Multiply(Multiply \$parameters)",
+                    "DivideResponse Divide(Divide \$parameters)",
+                ]
+            );
+
         $functions = Soap::to(static::EXAMPLE_SOAP_ENDPOINT)->functions();
         $this->assertIsArray($functions);
         $this->assertNotEmpty($functions);
@@ -50,7 +66,8 @@ class SoapClassTest extends TestCase
     }
 }
 
-class ExampleSoapable implements Soapable {
+class ExampleSoapable implements Soapable
+{
 
     public function toSoap()
     {

--- a/tests/SoapClassTest.php
+++ b/tests/SoapClassTest.php
@@ -2,6 +2,7 @@
 
 namespace RicorocksDigitalAgency\Soap\Tests;
 
+use RicorocksDigitalAgency\Soap\Contracts\Soapable;
 use RicorocksDigitalAgency\Soap\Facades\Soap;
 use RicorocksDigitalAgency\Soap\Response\Response;
 use Spatie\Ray\Ray;
@@ -38,5 +39,24 @@ class SoapClassTest extends TestCase
         Soap::fake(['*' => Response::new(['AddResult' => 35])]);
         $result = Soap::to(static::EXAMPLE_SOAP_ENDPOINT)->Add(['intA' => 10, 'intB' => 25]);
         $this->assertEquals(35, $result->AddResult);
+    }
+
+    /** @test */
+    public function it_works_with_a_soapable()
+    {
+        Soap::fake(['*' => Response::new(['AddResult' => 35])]);
+        $result = Soap::to(static::EXAMPLE_SOAP_ENDPOINT)->Add(new ExampleSoapable);
+        $this->assertEquals(35, $result->AddResult);
+    }
+}
+
+class ExampleSoapable implements Soapable {
+
+    public function toSoap()
+    {
+        return [
+            'intA' => 10,
+            'intB' => 25
+        ];
     }
 }


### PR DESCRIPTION
This Contract adds a `toSoap` method to the implementing class. Any class implementing this interface can be passed directly as a parameter, or as a sub-parameter, to a SOAP call and will automatically be transformed by the Soap package.

This is useful for Translator classes, but also could be used in many other contexts. For example, `soap_node()` has been refactored to make use of `Soapable`.

> In order to avoid a breaking change, `Node` still implements `Arrayable`.