### PR TITLE
Feature/soap headers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         }
     },
     "require": {
+        "ext-soap": "*",
         "illuminate/support": "^8.16"
     },
     "require-dev": {

--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -40,6 +40,10 @@ interface Request
 
     public function withOptions(array $options): self;
 
+    public function withHeaders(array $options): self;
+
+    public function withNamespace(string $namespace): self;
+
     public function withBasicAuth($login, $password): self;
 
     public function withDigestAuth($login, $password): self;

--- a/src/Request/SoapClientRequest.php
+++ b/src/Request/SoapClientRequest.php
@@ -6,6 +6,10 @@ use RicorocksDigitalAgency\Soap\Parameters\Builder;
 use RicorocksDigitalAgency\Soap\Response\Response;
 use RicorocksDigitalAgency\Soap\Support\Tracing\Trace;
 use SoapClient;
+use SoapHeader;
+use SoapVar;
+use function array_merge;
+use const SOAP_ENC_OBJECT;
 
 class SoapClientRequest implements Request
 {
@@ -17,6 +21,8 @@ class SoapClientRequest implements Request
     protected Response $response;
     protected $hooks = [];
     protected $options = [];
+    protected $headers = [];
+    protected $namespace = '';
 
     public function __construct(Builder $builder)
     {
@@ -66,15 +72,27 @@ class SoapClientRequest implements Request
         return $this->client()->{$this->getMethod()}($this->getBody());
     }
 
-    protected function client()
+    protected function client(): SoapClient
     {
-        return $this->client ??= app(
-            SoapClient::class,
-            [
-                'wsdl' => $this->endpoint,
-                'options' => $this->options
-            ]
-        );
+        if (!$this->client) {
+            $this->client = app(
+                SoapClient::class,
+                [
+                    'wsdl' => $this->endpoint,
+                    'options' => $this->options,
+                ]
+            );
+        }
+
+        /**
+         * @var string $headerTag
+         * @var mixed $headerValue
+         */
+        foreach ($this->headers as $headerTag => $headerValue) {
+            $this->addSoapHeader($headerTag, $headerValue);
+        }
+
+        return $this->client;
     }
 
     public function getMethod()
@@ -163,9 +181,63 @@ class SoapClientRequest implements Request
         return $this->options;
     }
 
+    public function getHeaders(): array
+    {
+        return $this->headers;
+    }
+
+    public function getNamespace(): string
+    {
+        return $this->namespace;
+    }
+
     public function withOptions(array $options): Request
     {
         $this->options = array_merge($this->getOptions(), $options);
+
         return $this;
+    }
+
+    public function withHeaders(array $headers): Request
+    {
+        $this->headers = array_merge($this->getHeaders(), $headers);
+
+        return $this;
+    }
+
+    public function withNamespace(string $namespace): Request
+    {
+        $this->namespace = $namespace;
+
+        return $this;
+    }
+
+    /**
+     * @param $headerValue
+     * @param string $headerTag
+     */
+    protected function addSoapHeader(string $headerTag, $headerValue): void
+    {
+        if (!$this->client) {
+            return;
+        }
+
+        /** @var SoapVar $soapVar */
+        $soapVar = new SoapVar(
+            $headerValue,
+            SOAP_ENC_OBJECT,
+            $headerTag,
+            $this->getNamespace()
+        );
+
+        /** @var SoapHeader $soapHeader */
+        $soapHeader = new SoapHeader(
+            $this->getNamespace(),
+            $headerTag,
+            $soapVar,
+            true
+        );
+
+        $this->client->__setSoapHeaders($soapHeader);
     }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Feature

**What is the new behavior?**
Fix #21 

**Does this PR introduce a breaking change?**
No

**Other information:**
Then it's possible to do something like
```php
/** @var string */
public const URL = 'https://sampledomain.com/soapservice.asmx?wsdl';

/** @var string */
public const NAMESPACE = 'http://www.sampledomain.com/';

/** @var array $headers */
$headers = [
    'AuthHeader' => [
        'Username' => self::USERNAME,
        'Password' => self::PASSWORD,
    ],
];

/** @var Response $data */
$data = Soap::to(self::URL)
             ->withNamespace(self::NAMESPACE)
             ->withHeaders($headers)
             ->call([...]);
```
to get:
```xml
<soap:Header>
  <AuthHeader xmlns="http://www.sampledomain.com/">
    <Username>user</Username>
    <Password>password</Password>
  </AuthHeader>
</soap:Header>
```
There are 2 points where I'm unsure:
- I don't know how to unit test this feature
- I don't like the fact I have to explicitly pass also the namespace, but I didn't find proper way to get it from the client, after it's instantiated with WSDL file.
