### PR TITLE
Headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A Laravel SOAP client that provides a clean interface for handling requests and 
 - [Using Soap](#using-soap)
 - [Features/API](#features/api)
     * [Headers](#headers)
+        * [Global Headers](#global-headers)
     * [To](#to)
     * [Functions](#functions)
     * [Call](#call)

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ $header = Soap::header()
                 'password' => '...'
             ])
             ->mustUnderstand()
-            ->author('foo.co.uk')
+            ->actor('foo.co.uk')
 ```
 This can also be expressed as:
 ```php
@@ -74,7 +74,7 @@ $header = Soap::header('Authentication', 'test.com', [
                 'password' => '...'
             ])
             ->mustUnderstand()
-            ->author('foo.co.uk')
+            ->actor('foo.co.uk')
 ```
 Plus, the `soap_header` helper method can be used:
 ```php

--- a/README.md
+++ b/README.md
@@ -9,15 +9,16 @@ A Laravel SOAP client that provides a clean interface for handling requests and 
 - [Installation](#installation)
 - [Using Soap](#using-soap)
 - [Features/API](#features/api)
+    * [Headers](#headers)
     * [To](#to)
     * [Functions](#functions)
     * [Call](#call)
         * [Parameters](#parameters)
             * [Nodes](#nodes)
-- [Options](#options)
-  * [Tracing](#tracing)
-  * [Authentication](#authentication)
-  * [Global Options](#global-options)
+    * [Options](#options)
+        * [Tracing](#tracing)
+        * [Authentication](#authentication)
+        * [Global Options](#global-options)
 - [Hooks](#hooks)
 - [Faking](#faking)
 - [Configuration](#configuration)
@@ -45,6 +46,62 @@ Soap::to()
 
 ## Features/API
 
+### Headers
+
+You can set the headers for each soap request that will be passed to the Soap Client using the `withHeaders` method.
+
+```php
+Soap::to('...')->withHeaders(...$headers)->call('...');
+```
+
+Each header should be a `Header` instance, which provides a fluent interface for constructing a new [PHP Soap Header](https://www.php.net/manual/en/soapheader.construct.php) and can be composed as follows:
+```php
+$header = Soap::header()
+            ->name('Authentication')
+            ->namespace('test.com')
+            ->data([
+                'user' => '...',
+                'password' => '...'
+            ])
+            ->mustUnderstand()
+            ->author('foo.co.uk')
+```
+This can also be expressed as:
+```php
+$header = Soap::header('Authentication', 'test.com', [
+                'user' => '...',
+                'password' => '...'
+            ])
+            ->mustUnderstand()
+            ->author('foo.co.uk')
+```
+Plus, the `soap_header` helper method can be used:
+```php
+$header = soap_header('Authentication', 'test.com')
+            ->data([
+                'user' => '...',
+                'password' => '...'
+            ])
+```
+> The `data` for the header can either be an array or a `SoapVar`, as per the `SoapHeader` constructor
+#### Global Headers
+Soap allows you to set headers that should be included for every request:
+```php
+Soap::headers(...$headers)
+```
+Again, each header should be an instance of `Header`.
+
+You may also want to include headers on every request, but only for a certain endpoint or action:
+
+```php
+// Only requests to this endpoint will include these headers
+Soap::headers(soap_header('Auth', 'test.com'))->for('https://api.example.com');
+
+// Only requests to this endpoint and the method Customers will include these headers
+Soap::headers(soap_header('Brand', 'test.com'))->for('https://api.example.com', 'Customers');
+```
+
+These calls are usually placed in the `boot` method of one of your application's Service Providers.
 ### To
 
 The endpoint to be accessed
@@ -151,7 +208,7 @@ Now, just by adding or removing a body to the `soap_node()` the outputted array 
 
 A node can be made with either the Facade `Soap::node()` or the helper method `soap_node()`.
 
-## Options
+### Options
 
 You can set custom options for each soap request that will be passed to the Soap Client using the `withOptions` method.
 
@@ -159,13 +216,13 @@ You can set custom options for each soap request that will be passed to the Soap
 Soap::to('...')->withOptions(['soap_version' => SOAP_1_2])->call('...');
 ```
 
-See [https://www.php.net/manual/en/soapclient.construct.php](https://www.php.net/manual/en/soapclient.construct.php)
+> See [https://www.php.net/manual/en/soapclient.construct.php](https://www.php.net/manual/en/soapclient.construct.php)
 for more details and available options.
 
 Soap also provides a number of methods that add syntactical sugar to the most commonly used options, which are detailed
 below.
 
-### Tracing
+#### Tracing
 Soap allows you to easily trace your interactions with the SOAP endpoint being accessed.
 
 To trace all requests, set the following in the register method of your `ServiceProvider`:
@@ -173,7 +230,11 @@ To trace all requests, set the following in the register method of your `Service
 ```php
 Soap::trace()
 ```
-Now, all `Response` objects returned will have a `Trace` object attached, accessible via `$response->getTrace()`. This has two properties `xmlRequest` and `xmlResponse` - storing the raw XML values for each.
+Now, all `Response` objects returned will have a `Trace` object attached, accessible via `$response->getTrace()`. This has four properties which are wrappers for the respective methods found on the `SoapClient`:
+- `xmlRequest` (`__getLastRequest`)
+- `xmlResponse` (`__getLastResponse`)
+- `requestHeaders` (`__getLastRequestHeaders`)
+- `responseHeaders` (`__getLastResponseHeaders`)
 
 Tracing can also be declared locally:
 ```php
@@ -183,7 +244,7 @@ Now, just this `Response` will have a valid `Trace`.
 
 Tracing is null safe. If `$response->getTrace()` is called when a `Trace` hasn't been set, a new `Trace` is returned. This `Trace`'s properties will all return `null`.
 
-### Authentication
+#### Authentication
 
 You can authenticate using Basic or Digest by calling `withBasicAuth` and `withDigestAuth` respectively.
 
@@ -192,7 +253,7 @@ Soap::to('...')->withBasicAuth('username', 'password')->call('...');
 Soap::to('...')->withDigestAuth('username', 'password')->call('...');
 ```
 
-### Global Options
+#### Global Options
 
 Sometimes, you may wish to include the same set of options on every SOAP request. You can do that using the `options`
 method on the `Soap` facade:

--- a/src/Facades/Soap.php
+++ b/src/Facades/Soap.php
@@ -6,6 +6,7 @@ namespace RicorocksDigitalAgency\Soap\Facades;
 
 use Illuminate\Support\Facades\Facade;
 use RicorocksDigitalAgency\Soap\Header;
+use RicorocksDigitalAgency\Soap\HeaderSet;
 use RicorocksDigitalAgency\Soap\Inclusion;
 use RicorocksDigitalAgency\Soap\OptionSet;
 use RicorocksDigitalAgency\Soap\Parameters\Node;
@@ -17,6 +18,7 @@ use RicorocksDigitalAgency\Soap\Request\Request;
  *
  * @method static Request to(string $endpoint)
  * @method static Header header(?string $name = null, ?string $namespace = null, $data = null)
+ * @method static HeaderSet headers(Header ...$headers)
  * @method static Node node(array $attributes = [])
  * @method static Inclusion include(array $parameters)
  * @method static OptionSet options(array $options)

--- a/src/Facades/Soap.php
+++ b/src/Facades/Soap.php
@@ -4,8 +4,8 @@
 namespace RicorocksDigitalAgency\Soap\Facades;
 
 
-use Closure;
 use Illuminate\Support\Facades\Facade;
+use RicorocksDigitalAgency\Soap\Header;
 use RicorocksDigitalAgency\Soap\Inclusion;
 use RicorocksDigitalAgency\Soap\OptionSet;
 use RicorocksDigitalAgency\Soap\Parameters\Node;
@@ -16,6 +16,7 @@ use RicorocksDigitalAgency\Soap\Request\Request;
  * @package RicorocksDigitalAgency\Soap\Facades
  *
  * @method static Request to(string $endpoint)
+ * @method static Header header(?string $name = null, ?string $namespace = null, $data = null)
  * @method static Node node(array $attributes = [])
  * @method static Inclusion include(array $parameters)
  * @method static OptionSet options(array $options)

--- a/src/Facades/Soap.php
+++ b/src/Facades/Soap.php
@@ -17,7 +17,7 @@ use RicorocksDigitalAgency\Soap\Request\Request;
  * @package RicorocksDigitalAgency\Soap\Facades
  *
  * @method static Request to(string $endpoint)
- * @method static Header header(?string $name = null, ?string $namespace = null, $data = null)
+ * @method static Header header(?string $name = null, ?string $namespace = null, $data = null, bool $mustUnderstand = false, ?string $actor = null)
  * @method static HeaderSet headers(Header ...$headers)
  * @method static Node node(array $attributes = [])
  * @method static Inclusion include(array $parameters)

--- a/src/Header.php
+++ b/src/Header.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace RicorocksDigitalAgency\Soap;
+
+use Illuminate\Contracts\Support\Arrayable;
+
+class Header implements Arrayable
+{
+    public $name;
+    public $namespace;
+    public $data;
+    public $actor;
+    public $mustUnderstand = false;
+
+    public function __construct(?string $name = null, ?string $namespace = null, $data = null)
+    {
+        $this->name = $name;
+        $this->namespace = $namespace;
+        $this->data = $data;
+    }
+
+    public function name(string $name): self
+    {
+        return tap($this, fn () => $this->name = $name);
+    }
+
+    public function namespace(string $namespace): self
+    {
+        return tap($this, fn () => $this->namespace = $namespace);
+    }
+
+    public function data($data): self
+    {
+        return tap($this, fn () => $this->data = $data);
+    }
+
+    public function actor(string $actor): self
+    {
+        return tap($this, fn () => $this->actor = $actor);
+    }
+
+    public function mustUnderstand(bool $mustUnderstand = true): self
+    {
+        return tap($this, fn () => $this->mustUnderstand = $mustUnderstand);
+    }
+
+    public function toArray()
+    {
+        return [
+            'name' => $this->name,
+            'namespace' => $this->namespace,
+            'data' => $this->data,
+            'mustUnderstand' => $this->mustUnderstand,
+            'actor' => $this->actor,
+        ];
+    }
+}

--- a/src/Header.php
+++ b/src/Header.php
@@ -10,13 +10,15 @@ class Header implements Arrayable
     public $namespace;
     public $data;
     public $actor;
-    public $mustUnderstand = false;
+    public $mustUnderstand;
 
-    public function __construct(?string $name = null, ?string $namespace = null, $data = null)
+    public function __construct(?string $name = null, ?string $namespace = null, $data = null, bool $mustUnderstand = false, ?string $actor = null)
     {
         $this->name = $name;
         $this->namespace = $namespace;
         $this->data = $data;
+        $this->mustUnderstand = $mustUnderstand;
+        $this->actor = $actor;
     }
 
     public function name(string $name): self
@@ -29,12 +31,12 @@ class Header implements Arrayable
         return tap($this, fn () => $this->namespace = $namespace);
     }
 
-    public function data($data): self
+    public function data($data = null): self
     {
         return tap($this, fn () => $this->data = $data);
     }
 
-    public function actor(string $actor): self
+    public function actor(?string $actor = null): self
     {
         return tap($this, fn () => $this->actor = $actor);
     }

--- a/src/HeaderSet.php
+++ b/src/HeaderSet.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace RicorocksDigitalAgency\Soap;
+
+use RicorocksDigitalAgency\Soap\Support\Scoped;
+
+class HeaderSet extends Scoped
+{
+    protected $headers;
+
+    public function __construct(Header ...$headers)
+    {
+        $this->headers = $headers;
+    }
+
+    public function getHeaders()
+    {
+        return $this->headers;
+    }
+}

--- a/src/Ray/SoapWatcher.php
+++ b/src/Ray/SoapWatcher.php
@@ -35,10 +35,18 @@ class SoapWatcher extends Watcher
             [
                 'Endpoint' => $request->getEndpoint(),
                 'Method' => $request->getMethod(),
+                'Headers' => $this->headers($request),
                 'Request' => $request->getBody(),
                 'Response' => $response->response,
             ],
             "SOAP"
         );
+    }
+
+    protected function headers(Request $request)
+    {
+        return $request->getHeaders()
+            ? collect($request->getHeaders())->map->toArray()->toArray()
+            : [];
     }
 }

--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -2,6 +2,7 @@
 
 namespace RicorocksDigitalAgency\Soap\Request;
 
+use RicorocksDigitalAgency\Soap\Header;
 use RicorocksDigitalAgency\Soap\Response\Response;
 
 interface Request
@@ -43,4 +44,8 @@ interface Request
     public function withBasicAuth($login, $password): self;
 
     public function withDigestAuth($login, $password): self;
+
+    public function withHeaders(Header ...$headers): self;
+
+    public function getHeaders(): array;
 }

--- a/src/Request/SoapClientRequest.php
+++ b/src/Request/SoapClientRequest.php
@@ -60,7 +60,9 @@ class SoapClientRequest implements Request
     {
         return tap(
             Response::new($this->makeRequest()),
-            fn($response) => data_get($this->options, 'trace') ? $this->addTrace($response) : $response
+            fn($response) => data_get($this->options, 'trace')
+                ? $response->setTrace(Trace::client($this->client()))
+                : $response
         );
     }
 
@@ -111,14 +113,6 @@ class SoapClientRequest implements Request
     public function getBody()
     {
         return $this->body;
-    }
-
-    protected function addTrace($response)
-    {
-        return $response->setTrace(
-            Trace::thisXmlRequest($this->client()->__getLastRequest())
-                ->thisXmlResponse($this->client()->__getLastResponse())
-        );
     }
 
     public function functions(): array

--- a/src/Request/SoapClientRequest.php
+++ b/src/Request/SoapClientRequest.php
@@ -83,9 +83,7 @@ class SoapClientRequest implements Request
             'options' => $this->options
         ]);
 
-        $client->__setSoapHeaders($this->constructHeaders());
-
-        return $client;
+        return tap($client, fn ($client) => $client->__setSoapHeaders($this->constructHeaders()));
     }
 
     protected function constructHeaders()
@@ -101,7 +99,8 @@ class SoapClientRequest implements Request
                 'data' => $header->data,
                 'mustUnderstand' => $header->mustUnderstand,
                 'actor' => $header->actor
-            ]), $this->headers
+            ]),
+            $this->headers
         );
     }
 

--- a/src/Soap.php
+++ b/src/Soap.php
@@ -42,6 +42,11 @@ class Soap
         return new Node($attributes);
     }
 
+    public function header(?string $name = null, ?string $namespace = null, $data = null): Header
+    {
+        return new Header($name, $namespace, $data);
+    }
+
     public function include($parameters)
     {
         $inclusion = new Inclusion($parameters);

--- a/src/Soap.php
+++ b/src/Soap.php
@@ -24,16 +24,16 @@ class Soap
     public function __construct(Fakery $fakery)
     {
         $this->fakery = $fakery;
-        $this->beforeRequesting(fn($request) => $request->fakeUsing($this->fakery->mockResponseIfAvailable($request)));
-        $this->beforeRequesting(fn($request) => $this->mergeHeadersFor($request));
-        $this->beforeRequesting(fn($request) => $this->mergeInclusionsFor($request));
-        $this->beforeRequesting(fn($request) => $this->mergeOptionsFor($request));
-        $this->afterRequesting(fn($request, $response) => $this->record($request, $response));
+        $this->beforeRequesting(fn($request) => $request->fakeUsing($this->fakery->mockResponseIfAvailable($request)))
+            ->beforeRequesting(fn($request) => $this->mergeHeadersFor($request))
+            ->beforeRequesting(fn($request) => $this->mergeInclusionsFor($request))
+            ->beforeRequesting(fn($request) => $this->mergeOptionsFor($request))
+            ->afterRequesting(fn($request, $response) => $this->record($request, $response));
     }
 
     public function to(string $endpoint)
     {
-        return app(Request::class)
+        return resolve(Request::class)
             ->beforeRequesting(...$this->globalHooks['beforeRequesting'])
             ->afterRequesting(...$this->globalHooks['afterRequesting'])
             ->to($endpoint);

--- a/src/Support/Tracing/Trace.php
+++ b/src/Support/Tracing/Trace.php
@@ -4,16 +4,21 @@ namespace RicorocksDigitalAgency\Soap\Support\Tracing;
 
 class Trace
 {
+    public $client;
     public $xmlRequest;
     public $xmlResponse;
+    public $requestHeaders;
+    public $responseHeaders;
 
-    public static function thisXmlRequest($xml): self
+    public static function client($client): self
     {
-        return tap(new static, fn($instance) => $instance->xmlRequest = $xml);
-    }
+        $trace = new static;
+        $trace->client = $client;
+        $trace->xmlRequest = $client->__getLastRequest();
+        $trace->xmlResponse = $client->__getLastResponse();
+        $trace->requestHeaders = $client->__getLastRequestHeaders();
+        $trace->responseHeaders = $client->__getLastResponseHeaders();
 
-    public function thisXmlResponse($xml): self
-    {
-        return tap($this, fn($self) => $self->xmlResponse = $xml);
+        return $trace;
     }
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -7,3 +7,9 @@ if (!function_exists('soap_node')) {
         return Soap::node($attributes);
     }
 }
+
+if (!function_exists('soap_header')) {
+    function soap_header(?string $name = null, ?string $namespace = null, $data = null) {
+        return Soap::header($name, $namespace, $data);
+    }
+}

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -9,7 +9,7 @@ if (!function_exists('soap_node')) {
 }
 
 if (!function_exists('soap_header')) {
-    function soap_header(?string $name = null, ?string $namespace = null, $data = null) {
-        return Soap::header($name, $namespace, $data);
+    function soap_header(?string $name = null, ?string $namespace = null, $data = null, bool $mustUnderstand = false, ?string $actor = null) {
+        return Soap::header($name, $namespace, $data, $mustUnderstand, $actor);
     }
 }

--- a/tests/Headers/GlobalHeadersTest.php
+++ b/tests/Headers/GlobalHeadersTest.php
@@ -12,12 +12,12 @@ class GlobalHeadersTest extends TestCase
     {
         Soap::fake();
 
-        Soap::headers(soap_header('Auth', 'xml', ['foo' => 'bar']));
+        Soap::headers(soap_header('Auth', 'test.com', ['foo' => 'bar']));
         Soap::to(static::EXAMPLE_SOAP_ENDPOINT)->call('Add', (['intB' => 25]));
 
         Soap::assertSent(function($request) {
             return $request->getHeaders() == [
-                soap_header('Auth', 'xml', ['foo' => 'bar'])
+                soap_header('Auth', 'test.com', ['foo' => 'bar'])
             ];
         });
     }
@@ -27,14 +27,14 @@ class GlobalHeadersTest extends TestCase
     {
         Soap::fake();
 
-        Soap::headers(soap_header('Brand', 'xmls', ['hello' => 'world']))->for('https://foo.bar');
-        Soap::headers(soap_header('Auth', 'xml', ['foo' => 'bar']))->for(static::EXAMPLE_SOAP_ENDPOINT);
+        Soap::headers(soap_header('Brand', 'test.coms', ['hello' => 'world']))->for('https://foo.bar');
+        Soap::headers(soap_header('Auth', 'test.com', ['foo' => 'bar']))->for(static::EXAMPLE_SOAP_ENDPOINT);
 
         Soap::to(static::EXAMPLE_SOAP_ENDPOINT)->call('Add', (['intB' => 25]));
 
         Soap::assertSent(function($request) {
             return $request->getHeaders() == [
-                soap_header('Auth', 'xml', ['foo' => 'bar'])
+                soap_header('Auth', 'test.com', ['foo' => 'bar'])
             ];
         });
     }
@@ -44,14 +44,14 @@ class GlobalHeadersTest extends TestCase
     {
         Soap::fake();
 
-        Soap::headers(soap_header('Brand', 'xmls', ['hello' => 'world']))->for(static::EXAMPLE_SOAP_ENDPOINT, 'Add');
-        Soap::headers(soap_header('Auth', 'xml', ['foo' => 'bar']))->for(static::EXAMPLE_SOAP_ENDPOINT, 'Subtract');
+        Soap::headers(soap_header('Brand', 'test.coms', ['hello' => 'world']))->for(static::EXAMPLE_SOAP_ENDPOINT, 'Add');
+        Soap::headers(soap_header('Auth', 'test.com', ['foo' => 'bar']))->for(static::EXAMPLE_SOAP_ENDPOINT, 'Subtract');
 
         Soap::to(static::EXAMPLE_SOAP_ENDPOINT)->call('Add', (['intB' => 25]));
 
         Soap::assertSent(function($request) {
             return $request->getHeaders() == [
-                soap_header('Brand', 'xmls', ['hello' => 'world'])
+                soap_header('Brand', 'test.coms', ['hello' => 'world'])
             ];
         });
     }
@@ -61,16 +61,16 @@ class GlobalHeadersTest extends TestCase
     {
         Soap::fake();
 
-        Soap::headers(soap_header('Brand', 'xmls', ['hello' => 'world']));
+        Soap::headers(soap_header('Brand', 'test.coms', ['hello' => 'world']));
 
         Soap::to(static::EXAMPLE_SOAP_ENDPOINT)
-            ->withHeaders(soap_header('Auth', 'xml', ['foo' => 'bar']))
+            ->withHeaders(soap_header('Auth', 'test.com', ['foo' => 'bar']))
             ->call('Add', (['intB' => 25]));
 
         Soap::assertSent(function($request) {
             return $request->getHeaders() == [
-                soap_header('Auth', 'xml', ['foo' => 'bar']),
-                soap_header('Brand', 'xmls', ['hello' => 'world'])
+                soap_header('Auth', 'test.com', ['foo' => 'bar']),
+                soap_header('Brand', 'test.coms', ['hello' => 'world'])
             ];
         });
     }

--- a/tests/Headers/GlobalHeadersTest.php
+++ b/tests/Headers/GlobalHeadersTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace RicorocksDigitalAgency\Soap\Tests\Headers;
+
+use RicorocksDigitalAgency\Soap\Facades\Soap;
+use RicorocksDigitalAgency\Soap\Tests\TestCase;
+
+class GlobalHeadersTest extends TestCase
+{
+    /** @test */
+    public function it_can_include_global_headers_for_every_request()
+    {
+        Soap::fake();
+
+        Soap::headers(soap_header('Auth', 'xml', ['foo' => 'bar']));
+        Soap::to(static::EXAMPLE_SOAP_ENDPOINT)->call('Add', (['intB' => 25]));
+
+        Soap::assertSent(function($request) {
+            return $request->getHeaders() == [
+                soap_header('Auth', 'xml', ['foo' => 'bar'])
+            ];
+        });
+    }
+
+    /** @test */
+    public function it_can_scope_headers_based_on_the_endpoint()
+    {
+        Soap::fake();
+
+        Soap::headers(soap_header('Brand', 'xmls', ['hello' => 'world']))->for('https://foo.bar');
+        Soap::headers(soap_header('Auth', 'xml', ['foo' => 'bar']))->for(static::EXAMPLE_SOAP_ENDPOINT);
+
+        Soap::to(static::EXAMPLE_SOAP_ENDPOINT)->call('Add', (['intB' => 25]));
+
+        Soap::assertSent(function($request) {
+            return $request->getHeaders() == [
+                soap_header('Auth', 'xml', ['foo' => 'bar'])
+            ];
+        });
+    }
+
+    /** @test */
+    public function it_can_scope_headers_based_on_the_endpoint_and_method()
+    {
+        Soap::fake();
+
+        Soap::headers(soap_header('Brand', 'xmls', ['hello' => 'world']))->for(static::EXAMPLE_SOAP_ENDPOINT, 'Add');
+        Soap::headers(soap_header('Auth', 'xml', ['foo' => 'bar']))->for(static::EXAMPLE_SOAP_ENDPOINT, 'Subtract');
+
+        Soap::to(static::EXAMPLE_SOAP_ENDPOINT)->call('Add', (['intB' => 25]));
+
+        Soap::assertSent(function($request) {
+            return $request->getHeaders() == [
+                soap_header('Brand', 'xmls', ['hello' => 'world'])
+            ];
+        });
+    }
+
+    /** @test */
+    public function the_global_headers_are_merged_with_local_headers()
+    {
+        Soap::fake();
+
+        Soap::headers(soap_header('Brand', 'xmls', ['hello' => 'world']));
+
+        Soap::to(static::EXAMPLE_SOAP_ENDPOINT)
+            ->withHeaders(soap_header('Auth', 'xml', ['foo' => 'bar']))
+            ->call('Add', (['intB' => 25]));
+
+        Soap::assertSent(function($request) {
+            return $request->getHeaders() == [
+                soap_header('Auth', 'xml', ['foo' => 'bar']),
+                soap_header('Brand', 'xmls', ['hello' => 'world'])
+            ];
+        });
+    }
+}

--- a/tests/Headers/HeadersTest.php
+++ b/tests/Headers/HeadersTest.php
@@ -5,6 +5,7 @@ namespace RicorocksDigitalAgency\Soap\Tests\Headers;
 use RicorocksDigitalAgency\Soap\Facades\Soap;
 use RicorocksDigitalAgency\Soap\Request\SoapClientRequest;
 use RicorocksDigitalAgency\Soap\Tests\TestCase;
+use SoapVar;
 
 class HeadersTest extends TestCase
 {
@@ -109,6 +110,24 @@ class HeadersTest extends TestCase
             function (SoapClientRequest $request, $response) {
                 return $request->getHeaders() == [
                     Soap::header('Auth', 'xml')->data(['foo' => 'bar'])
+                ];
+            }
+        );
+    }
+
+    /** @test */
+    public function a_header_can_be_set_using_a_SoapVar()
+    {
+        Soap::fake();
+
+        Soap::to(static::EXAMPLE_SOAP_ENDPOINT)
+            ->withHeaders(soap_header('Auth', 'xml', new SoapVar(['foo' => 'bar'], null)))
+            ->call('Add', ['intA' => 10, 'intB' => 25]);
+
+        Soap::assertSent(
+            function (SoapClientRequest $request, $response) {
+                return $request->getHeaders() == [
+                    Soap::header('Auth', 'xml')->data(new SoapVar(['foo' => 'bar'], null))
                 ];
             }
         );

--- a/tests/Headers/HeadersTest.php
+++ b/tests/Headers/HeadersTest.php
@@ -15,13 +15,13 @@ class HeadersTest extends TestCase
         Soap::fake();
 
         Soap::to(static::EXAMPLE_SOAP_ENDPOINT)
-            ->withHeaders(Soap::header('Auth', 'xml')->data(['foo' => 'bar']))
+            ->withHeaders(Soap::header('Auth', 'test.com')->data(['foo' => 'bar']))
             ->call('Add', ['intA' => 10, 'intB' => 25]);
 
         Soap::assertSent(
             function (SoapClientRequest $request, $response) {
                 return $request->getHeaders() == [
-                    Soap::header('Auth', 'xml')->data(['foo' => 'bar'])
+                    Soap::header('Auth', 'test.com')->data(['foo' => 'bar'])
                 ];
             }
         );
@@ -34,16 +34,16 @@ class HeadersTest extends TestCase
 
         Soap::to(static::EXAMPLE_SOAP_ENDPOINT)
             ->withHeaders(
-                Soap::header('Auth', 'xml')->data(['foo' => 'bar']),
-                Soap::header('Brand', 'xml')->data(['hello' => 'world'])
+                Soap::header('Auth', 'test.com')->data(['foo' => 'bar']),
+                Soap::header('Brand', 'test.com')->data(['hello' => 'world'])
             )
             ->call('Add', ['intA' => 10, 'intB' => 25]);
 
         Soap::assertSent(
             function (SoapClientRequest $request, $response) {
                 return $request->getHeaders() == [
-                    Soap::header('Auth', 'xml')->data(['foo' => 'bar']),
-                    Soap::header('Brand', 'xml')->data(['hello' => 'world']),
+                    Soap::header('Auth', 'test.com')->data(['foo' => 'bar']),
+                    Soap::header('Brand', 'test.com')->data(['hello' => 'world']),
                 ];
             }
         );
@@ -56,16 +56,16 @@ class HeadersTest extends TestCase
 
         Soap::to(static::EXAMPLE_SOAP_ENDPOINT)
             ->withHeaders(...[
-                Soap::header('Auth', 'xml')->data(['foo' => 'bar']),
-                Soap::header('Brand', 'xml')->data(['hello' => 'world'])
+                Soap::header('Auth', 'test.com')->data(['foo' => 'bar']),
+                Soap::header('Brand', 'test.com')->data(['hello' => 'world'])
             ])
             ->call('Add', ['intA' => 10, 'intB' => 25]);
 
         Soap::assertSent(
             function (SoapClientRequest $request, $response) {
                 return $request->getHeaders() == [
-                    Soap::header('Auth', 'xml')->data(['foo' => 'bar']),
-                    Soap::header('Brand', 'xml')->data(['hello' => 'world']),
+                    Soap::header('Auth', 'test.com')->data(['foo' => 'bar']),
+                    Soap::header('Brand', 'test.com')->data(['hello' => 'world']),
                 ];
             }
         );
@@ -78,16 +78,16 @@ class HeadersTest extends TestCase
 
         Soap::to(static::EXAMPLE_SOAP_ENDPOINT)
             ->withHeaders(...collect([
-                Soap::header('Auth', 'xml')->data(['foo' => 'bar']),
-                Soap::header('Brand', 'xml')->data(['hello' => 'world'])
+                Soap::header('Auth', 'test.com')->data(['foo' => 'bar']),
+                Soap::header('Brand', 'test.com')->data(['hello' => 'world'])
             ]))
             ->call('Add', ['intA' => 10, 'intB' => 25]);
 
         Soap::assertSent(
             function (SoapClientRequest $request, $response) {
                 return $request->getHeaders() == [
-                    Soap::header('Auth', 'xml')->data(['foo' => 'bar']),
-                    Soap::header('Brand', 'xml')->data(['hello' => 'world']),
+                    Soap::header('Auth', 'test.com')->data(['foo' => 'bar']),
+                    Soap::header('Brand', 'test.com')->data(['hello' => 'world']),
                 ];
             }
         );
@@ -99,15 +99,15 @@ class HeadersTest extends TestCase
         Soap::fake();
 
         Soap::to(static::EXAMPLE_SOAP_ENDPOINT)
-            ->withHeaders(Soap::header('Auth', 'xml')->data(['foo' => 'bar']))
-            ->withHeaders(Soap::header('Brand', 'xml')->data(['hello' => 'world']))
+            ->withHeaders(Soap::header('Auth', 'test.com')->data(['foo' => 'bar']))
+            ->withHeaders(Soap::header('Brand', 'test.com')->data(['hello' => 'world']))
             ->call('Add', ['intA' => 10, 'intB' => 25]);
 
         Soap::assertSent(
             function (SoapClientRequest $request, $response) {
                 return $request->getHeaders() == [
-                    Soap::header('Auth', 'xml')->data(['foo' => 'bar']),
-                    Soap::header('Brand', 'xml')->data(['hello' => 'world']),
+                    Soap::header('Auth', 'test.com')->data(['foo' => 'bar']),
+                    Soap::header('Brand', 'test.com')->data(['hello' => 'world']),
                 ];
             }
         );
@@ -122,7 +122,7 @@ class HeadersTest extends TestCase
             ->withHeaders(
                 Soap::header()
                     ->name('Auth')
-                    ->namespace('xml')
+                    ->namespace('test.com')
                     ->data(['foo' => 'bar'])
                     ->mustUnderstand()
                     ->actor('this.test')
@@ -132,7 +132,7 @@ class HeadersTest extends TestCase
         Soap::assertSent(
             function (SoapClientRequest $request, $response) {
                 return $request->getHeaders() == [
-                    Soap::header('Auth', 'xml')
+                    Soap::header('Auth', 'test.com')
                         ->data(['foo' => 'bar'])
                         ->mustUnderstand()
                         ->actor('this.test')
@@ -147,13 +147,13 @@ class HeadersTest extends TestCase
         Soap::fake();
 
         Soap::to(static::EXAMPLE_SOAP_ENDPOINT)
-            ->withHeaders(soap_header('Auth', 'xml', ['foo' => 'bar']))
+            ->withHeaders(soap_header('Auth', 'test.com', ['foo' => 'bar']))
             ->call('Add', ['intA' => 10, 'intB' => 25]);
 
         Soap::assertSent(
             function (SoapClientRequest $request, $response) {
                 return $request->getHeaders() == [
-                    Soap::header('Auth', 'xml')->data(['foo' => 'bar'])
+                    Soap::header('Auth', 'test.com')->data(['foo' => 'bar'])
                 ];
             }
         );
@@ -165,13 +165,33 @@ class HeadersTest extends TestCase
         Soap::fake();
 
         Soap::to(static::EXAMPLE_SOAP_ENDPOINT)
-            ->withHeaders(soap_header('Auth', 'xml', new SoapVar(['foo' => 'bar'], null)))
+            ->withHeaders(soap_header('Auth', 'test.com', new SoapVar(['foo' => 'bar'], null)))
             ->call('Add', ['intA' => 10, 'intB' => 25]);
 
         Soap::assertSent(
             function (SoapClientRequest $request, $response) {
                 return $request->getHeaders() == [
-                    Soap::header('Auth', 'xml')->data(new SoapVar(['foo' => 'bar'], null))
+                    Soap::header('Auth', 'test.com')->data(new SoapVar(['foo' => 'bar'], null))
+                ];
+            }
+        );
+    }
+
+    /** @test */
+    public function the_optional_parameters_of_the_SoapHeader_are_optional()
+    {
+        Soap::fake();
+
+        Soap::to(static::EXAMPLE_SOAP_ENDPOINT)
+            ->withHeaders(Soap::header('Auth', 'test.com')->data(null)->actor(null))
+            ->withHeaders(soap_header('Brand', 'test.com', null, false, null))
+            ->call('Add', ['intA' => 10, 'intB' => 25]);
+
+        Soap::assertSent(
+            function (SoapClientRequest $request, $response) {
+                return $request->getHeaders() == [
+                    Soap::header('Auth', 'test.com', null, false, null),
+                    Soap::header('Brand', 'test.com', null, false, null),
                 ];
             }
         );

--- a/tests/Headers/HeadersTest.php
+++ b/tests/Headers/HeadersTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace RicorocksDigitalAgency\Soap\Tests\Headers;
+
+use RicorocksDigitalAgency\Soap\Facades\Soap;
+use RicorocksDigitalAgency\Soap\Request\SoapClientRequest;
+use RicorocksDigitalAgency\Soap\Tests\TestCase;
+
+class HeadersTest extends TestCase
+{
+    /** @test */
+    public function headers_can_be_set()
+    {
+        Soap::fake();
+
+        Soap::to(static::EXAMPLE_SOAP_ENDPOINT)
+            ->withHeaders(Soap::header('Auth', 'xml')->data(['foo' => 'bar']))
+            ->call('Add', ['intA' => 10, 'intB' => 25]);
+
+        Soap::assertSent(
+            function (SoapClientRequest $request, $response) {
+                return $request->getHeaders() == [
+                    Soap::header('Auth', 'xml')->data(['foo' => 'bar'])
+                ];
+            }
+        );
+    }
+
+    /** @test */
+    public function multiple_headers_can_be_defined_in_the_same_method()
+    {
+        Soap::fake();
+
+        Soap::to(static::EXAMPLE_SOAP_ENDPOINT)
+            ->withHeaders(...[
+                Soap::header('Auth', 'xml')->data(['foo' => 'bar']),
+                Soap::header('Brand', 'xml')->data(['hello' => 'world']),
+            ])
+            ->call('Add', ['intA' => 10, 'intB' => 25]);
+
+        Soap::assertSent(
+            function (SoapClientRequest $request, $response) {
+                return $request->getHeaders() == [
+                    Soap::header('Auth', 'xml')->data(['foo' => 'bar']),
+                    Soap::header('Brand', 'xml')->data(['hello' => 'world']),
+                ];
+            }
+        );
+    }
+
+    /** @test */
+    public function multiple_headers_can_be_defined_in_the_multiple_methods()
+    {
+        Soap::fake();
+
+        Soap::to(static::EXAMPLE_SOAP_ENDPOINT)
+            ->withHeaders(Soap::header('Auth', 'xml')->data(['foo' => 'bar']))
+            ->withHeaders(Soap::header('Brand', 'xml')->data(['hello' => 'world']))
+            ->call('Add', ['intA' => 10, 'intB' => 25]);
+
+        Soap::assertSent(
+            function (SoapClientRequest $request, $response) {
+                return $request->getHeaders() == [
+                    Soap::header('Auth', 'xml')->data(['foo' => 'bar']),
+                    Soap::header('Brand', 'xml')->data(['hello' => 'world']),
+                ];
+            }
+        );
+    }
+
+    /** @test */
+    public function a_header_can_be_created_without_any_parameters_and_be_composed_fluently()
+    {
+        Soap::fake();
+
+        Soap::to(static::EXAMPLE_SOAP_ENDPOINT)
+            ->withHeaders(
+                Soap::header()
+                    ->name('Auth')
+                    ->namespace('xml')
+                    ->data(['foo' => 'bar'])
+                    ->mustUnderstand()
+                    ->actor('this.test')
+            )
+            ->call('Add', ['intA' => 10, 'intB' => 25]);
+
+        Soap::assertSent(
+            function (SoapClientRequest $request, $response) {
+                return $request->getHeaders() == [
+                    Soap::header('Auth', 'xml')
+                        ->data(['foo' => 'bar'])
+                        ->mustUnderstand()
+                        ->actor('this.test')
+                ];
+            }
+        );
+    }
+
+    /** @test */
+    public function a_header_can_be_created_with_the_helper_method()
+    {
+        Soap::fake();
+
+        Soap::to(static::EXAMPLE_SOAP_ENDPOINT)
+            ->withHeaders(soap_header('Auth', 'xml', ['foo' => 'bar']))
+            ->call('Add', ['intA' => 10, 'intB' => 25]);
+
+        Soap::assertSent(
+            function (SoapClientRequest $request, $response) {
+                return $request->getHeaders() == [
+                    Soap::header('Auth', 'xml')->data(['foo' => 'bar'])
+                ];
+            }
+        );
+    }
+}

--- a/tests/Headers/HeadersTest.php
+++ b/tests/Headers/HeadersTest.php
@@ -33,10 +33,54 @@ class HeadersTest extends TestCase
         Soap::fake();
 
         Soap::to(static::EXAMPLE_SOAP_ENDPOINT)
+            ->withHeaders(
+                Soap::header('Auth', 'xml')->data(['foo' => 'bar']),
+                Soap::header('Brand', 'xml')->data(['hello' => 'world'])
+            )
+            ->call('Add', ['intA' => 10, 'intB' => 25]);
+
+        Soap::assertSent(
+            function (SoapClientRequest $request, $response) {
+                return $request->getHeaders() == [
+                    Soap::header('Auth', 'xml')->data(['foo' => 'bar']),
+                    Soap::header('Brand', 'xml')->data(['hello' => 'world']),
+                ];
+            }
+        );
+    }
+
+    /** @test */
+    public function multiple_headers_can_be_defined_with_an_array_in_the_same_method()
+    {
+        Soap::fake();
+
+        Soap::to(static::EXAMPLE_SOAP_ENDPOINT)
             ->withHeaders(...[
                 Soap::header('Auth', 'xml')->data(['foo' => 'bar']),
-                Soap::header('Brand', 'xml')->data(['hello' => 'world']),
+                Soap::header('Brand', 'xml')->data(['hello' => 'world'])
             ])
+            ->call('Add', ['intA' => 10, 'intB' => 25]);
+
+        Soap::assertSent(
+            function (SoapClientRequest $request, $response) {
+                return $request->getHeaders() == [
+                    Soap::header('Auth', 'xml')->data(['foo' => 'bar']),
+                    Soap::header('Brand', 'xml')->data(['hello' => 'world']),
+                ];
+            }
+        );
+    }
+
+    /** @test */
+    public function multiple_headers_can_be_defined_with_a_collection_in_the_same_method()
+    {
+        Soap::fake();
+
+        Soap::to(static::EXAMPLE_SOAP_ENDPOINT)
+            ->withHeaders(...collect([
+                Soap::header('Auth', 'xml')->data(['foo' => 'bar']),
+                Soap::header('Brand', 'xml')->data(['hello' => 'world'])
+            ]))
             ->call('Add', ['intA' => 10, 'intB' => 25]);
 
         Soap::assertSent(

--- a/tests/Mocks/MockSoapClient.php
+++ b/tests/Mocks/MockSoapClient.php
@@ -46,6 +46,11 @@ class MockSoapClient
 
     public function __getLastRequestHeaders()
     {
+        if (!$this->shouldTrace) {
+            return null;
+        }
+
+        return 'Hello World';
     }
 
     public function __getLastResponse()
@@ -59,6 +64,11 @@ class MockSoapClient
 
     public function __getLastResponseHeaders()
     {
+        if (!$this->shouldTrace) {
+            return null;
+        }
+
+        return 'Foo Bar';
     }
 
     public function __getTypes()

--- a/tests/Options/OptionsTest.php
+++ b/tests/Options/OptionsTest.php
@@ -10,7 +10,6 @@ use RicorocksDigitalAgency\Soap\Tests\TestCase;
 
 class OptionsTest extends TestCase
 {
-
     /** @test */
     public function options_can_be_set()
     {
@@ -23,8 +22,8 @@ class OptionsTest extends TestCase
         Soap::assertSent(
             function (SoapClientRequest $request, $response) {
                 return $request->getOptions() == [
-                        'compression' => SOAP_COMPRESSION_GZIP,
-                    ];
+                    'compression' => SOAP_COMPRESSION_GZIP,
+                ];
             }
         );
     }
@@ -42,11 +41,11 @@ class OptionsTest extends TestCase
         Soap::assertSent(
             function (SoapClientRequest $request, $response) {
                 return $request->getOptions() == [
-                        'authentication' => SOAP_AUTHENTICATION_BASIC,
-                        'login' => 'foo',
-                        'password' => 'bar',
-                        'compression' => SOAP_COMPRESSION_GZIP,
-                    ];
+                    'authentication' => SOAP_AUTHENTICATION_BASIC,
+                    'login' => 'foo',
+                    'password' => 'bar',
+                    'compression' => SOAP_COMPRESSION_GZIP,
+                ];
             }
         );
     }
@@ -64,8 +63,8 @@ class OptionsTest extends TestCase
         Soap::assertSent(
             function (SoapClientRequest $request, $response) {
                 return $request->getOptions() == [
-                        'compression' => SOAP_COMPRESSION_GZIP,
-                    ];
+                    'compression' => SOAP_COMPRESSION_GZIP,
+                ];
             }
         );
     }

--- a/tests/Tracing/SoapTracingTest.php
+++ b/tests/Tracing/SoapTracingTest.php
@@ -23,6 +23,8 @@ class SoapTracingTest extends TestCase
 
         $this->assertEquals('<?xml version="1.0" encoding="UTF-8"?><FooBar><Hello>World</Hello></FooBar>', $response->trace()->xmlRequest);
         $this->assertEquals('<?xml version="1.0" encoding="UTF-8"?><Status>Success!</Status>', $response->trace()->xmlResponse);
+        $this->assertEquals('Hello World', $response->trace()->requestHeaders);
+        $this->assertEquals('Foo Bar', $response->trace()->responseHeaders);
     }
 
     /** @test */
@@ -35,6 +37,8 @@ class SoapTracingTest extends TestCase
 
         $this->assertEquals('<?xml version="1.0" encoding="UTF-8"?><FooBar><Hello>World</Hello></FooBar>', $response->trace()->xmlRequest);
         $this->assertEquals('<?xml version="1.0" encoding="UTF-8"?><Status>Success!</Status>', $response->trace()->xmlResponse);
+        $this->assertEquals('Hello World', $response->trace()->requestHeaders);
+        $this->assertEquals('Foo Bar', $response->trace()->responseHeaders);
     }
 
     /** @test */
@@ -45,5 +49,7 @@ class SoapTracingTest extends TestCase
 
         $this->assertEmpty($response->trace()->xmlRequest);
         $this->assertEmpty($response->trace()->xmlResponse);
+        $this->assertEmpty($response->trace()->requestHeaders);
+        $this->assertEmpty($response->trace()->responseHeaders);
     }
 }

--- a/tests/Tracing/TraceTest.php
+++ b/tests/Tracing/TraceTest.php
@@ -4,37 +4,19 @@ namespace RicorocksDigitalAgency\Soap\Tests\Tracing;
 
 use RicorocksDigitalAgency\Soap\Support\Tracing\Trace;
 use RicorocksDigitalAgency\Soap\Tests\TestCase;
+use SoapClient;
 
 class TraceTest extends TestCase
 {
     /** @test */
-    public function the_trace_object_has_a_static_thisXmlRequest_method()
+    public function the_trace_object_has_a_static_client_method()
     {
-        $xml = '<?xml version="1.0" encoding="UTF-8"?><FooBar><Hello>World</Hello></FooBar>';
+        $trace = Trace::client($client = new SoapClient(static::EXAMPLE_SOAP_ENDPOINT));
 
-        $trace = Trace::thisXmlRequest($xml);
-
-        $this->assertSame($xml, $trace->xmlRequest);
-    }
-
-    /** @test */
-    public function the_trace_object_has_a_thisXmlResponse_method()
-    {
-        $request = '<?xml version="1.0" encoding="UTF-8"?><FooBar><Hello>World</Hello></FooBar>';
-        $response = '<?xml version="1.0" encoding="UTF-8"?><Status>Success!</Status>';
-
-        $trace = Trace::thisXmlRequest($request)->thisXmlResponse($response);
-
-        $this->assertSame($response, $trace->xmlResponse);
-    }
-
-    /** @test */
-    public function a_null_trace_returns_gracefully()
-    {
-        $trace = Trace::thisXmlRequest(null)->thisXmlResponse(null);
-
-        $this->assertNull($trace->xmlRequest);
-        $this->assertNull($trace->xmlResponse);
+        $this->assertSame($client->__getLastRequest(), $trace->xmlRequest);
+        $this->assertSame($client->__getLastResponse(), $trace->xmlResponse);
+        $this->assertSame($client->__getLastRequestHeaders(), $trace->requestHeaders);
+        $this->assertSame($client->__getLastResponseHeaders(), $trace->responseHeaders);
     }
 
     /** @test */
@@ -42,7 +24,10 @@ class TraceTest extends TestCase
     {
         $trace = new Trace;
 
+        $this->assertNull($trace->client);
         $this->assertNull($trace->xmlRequest);
         $this->assertNull($trace->xmlResponse);
+        $this->assertNull($trace->requestHeaders);
+        $this->assertNull($trace->responseHeaders);
     }
 }


### PR DESCRIPTION
This introduces the ability to add Headers to a Soap request. 

A Header builder object is included so that the api is as so:

```php
$header = Soap::header('Authentication', 'test.com', [
                'user' => '...',
                'password' => '...'
            ])
            ->mustUnderstand()
            ->actor('foo.co.uk')

Soap::to('...')->withHeaders($header)
```

Or, the helper method can be used:
```php
$header = soap_header('Authentication', 'test.com', [
                'user' => '...',
                'password' => '...'
            ])
            ->mustUnderstand()
            ->actor('foo.co.uk')

Soap::to('...')->withHeaders($header)
```

Of course, the `withHeaders` method can accept multiple headers:
```php
Soap::to('...')->withHeaders($header, $anotherHeader, $yetAnotherHeader)
```

And global headers can also be configured - which can be scoped too:
```php
Soap::headers($header)->for('...')
```

The `Trace` object has also been updated to add support for request and response headers.