### PR TITLE
fix aliases attribute in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,9 +42,9 @@
             "providers": [
                 "RicorocksDigitalAgency\\Soap\\Providers\\SoapServiceProvider"
             ],
-            "aliases": [
-                "RicorocksDigitalAgency\\Soap\\Facades\\Soap"
-            ]
+            "aliases": {
+                "Soap": "RicorocksDigitalAgency\\Soap\\Facades\\Soap"
+            }
         }
     }
 }


### PR DESCRIPTION
Regarding to the docs of laravel package management's package discovery section the `aliases` attribute in composer.json should be a key-value paired list where the key is the alias class name, and the value is the class name with full namespace you want to alias.

See https://laravel.com/docs/9.x/packages#package-discovery

Currently this causes the following issue: The ide-helper generator generates an alias like this:
`class 0 extends \RicorocksDigitalAgency\Soap\Facades\Soap {}`

But I think it also prevents developers to use the alias itself e.g. `Soap::to('...')` without namespace
