### PR TITLE
Add accessors for lastRequest and lastResponse

### DIFF
--- a/src/Request/SoapClientRequest.php
+++ b/src/Request/SoapClientRequest.php
@@ -116,6 +116,14 @@ class SoapClientRequest implements Request
         return $this->body;
     }
 
+    public function getLastResponse() {
+        return $this->client()->__getLastResponse();
+    }
+
+    public function getLastRequest() {  
+        return $this->client()->__getLastRequest();
+    }
+
     public function functions(): array
     {
         return $this->client()->__getFunctions();


### PR DESCRIPTION
If the php soap client throws an exception, it's not currently possible to access the lastResponse and lastRequest via the Rocorocks-Digital-Agency Soap wrapper. Adding these two methods will expose them, making it much easier to debug things.

