### PR TITLE
Main to 1.x

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,9 +11,25 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['7.4', '8.0']
+        php: ['7.4', '8.0', '8.1', '8.2']
+        laravel: [ '8.*', '9.*', '10.*' ]
+        stability: [ prefer-lowest, prefer-stable ]
+        include:
+          - laravel: '10.*'
+            testbench: '8.*'
+          - laravel: '9.*'
+            testbench: '7.*'
+          - laravel: '8.*'
+            testbench: '^6.24'
+        exclude:
+          - laravel: 9.*
+            php: 7.4
+          - laravel: 10.*
+            php: 7.4
+          - laravel: 10.*
+            php: 8.0
 
-    name: PHP ${{ matrix.php }}
+    name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - ${{ matrix.stability }}
 
     steps:
       - name: Checkout
@@ -30,7 +46,9 @@ jobs:
         run: composer validate
 
       - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --no-suggest
+        run: |
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Run Pest
         run: php vendor/bin/pest

--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ specific, so you can pass the `fake` method an array of endpoints as keys
 and response objects as values:
 
 ```php
-Soap::fake(['http://endpoint.com' => Response(['foo' => 'bar'])]);
+Soap::fake(['http://endpoint.com' => Response::new(['foo' => 'bar'])]);
 ```
 
 In the above example, any SOAP request made to `http://endpoint.com` will
@@ -339,13 +339,13 @@ be returned instead.
 What if you want to specify the SOAP action too? Easy! Just add `:{ActionName}` after your endpoint, like so:
 
 ```php
-Soap::fake(['http://endpoint.com:Details' => Response(['foo' => 'bar'])]);
+Soap::fake(['http://endpoint.com:Details' => Response::new(['foo' => 'bar'])]);
 ```
 Now, only SOAP requests to the `Details` actions will be mocked.
 
 You can also specify multiple actions with the `|` operator:
 ```php
-Soap::fake(['http://endpoint.com:Details|Information|Overview' => Response(['foo' => 'bar'])]);
+Soap::fake(['http://endpoint.com:Details|Information|Overview' => Response::new(['foo' => 'bar'])]);
 ```
 Now, only SOAP requests to the `Details`, `Information` and `Overview` actions will be mocked.
 

--- a/composer.json
+++ b/composer.json
@@ -14,15 +14,17 @@
         }
     },
     "require": {
-        "php": "^7.4|^8.0",
-        "illuminate/support": "^8.16"
+        "php": "^7.4|~8.0|~8.1|~8.2",
+        "illuminate/support": "^8.16|^9.0|^10.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.4",
-        "orchestra/testbench": "^6.5",
-        "spatie/ray": "^1.17",
         "ext-soap": "*",
-        "pestphp/pest": "^1.0"
+        "mockery/mockery": "^1.4",
+        "orchestra/testbench": "^6.24|^7.0|^8.0",
+        "pestphp/pest": "^1.11",
+        "phpoption/phpoption": "^1.8.1",
+        "phpunit/phpunit": "^9.5",
+        "spatie/ray": "^1.17"
     },
     "prefer-stable": true,
     "authors": [
@@ -40,9 +42,14 @@
             "providers": [
                 "RicorocksDigitalAgency\\Soap\\Providers\\SoapServiceProvider"
             ],
-            "aliases": [
-                "RicorocksDigitalAgency\\Soap\\Facades\\Soap"
-            ]
+            "aliases": {
+                "Soap": "RicorocksDigitalAgency\\Soap\\Facades\\Soap"
+            }
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
         }
     }
 }


### PR DESCRIPTION
It seems we released some changes from `main` rather than `1.x`, this brings `1.x` up to date with `main` to allow for `main` to diverge for coming updates.